### PR TITLE
Gay water explosion and replication

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6748,6 +6748,8 @@
 #include "troutstation\code\modules\reagents\reagent_dispenser.dm"
 #include "troutstation\code\modules\reagents\chemistry\reagents\food_reagents.dm"
 #include "troutstation\code\modules\reagents\chemistry\reagents\drinks\drink_reagents.dm"
+#include "troutstation\code\modules\reagents\chemistry\recipes\other.dm"
+#include "troutstation\code\modules\reagents\chemistry\recipes\pyrotechnics.dm"
 #include "troutstation\code\modules\reagents\drinks\glass_styles\smoothies_shakes.dm"
 #include "troutstation\code\modules\reagents\reagent_containers\condiment.dm"
 #include "troutstation\code\modules\reagents\reagent_containers\cooler_jug.dm"

--- a/troutstation/code/modules/reagents/chemistry/recipes/other.dm
+++ b/troutstation/code/modules/reagents/chemistry/recipes/other.dm
@@ -1,0 +1,5 @@
+/datum/chemical_reaction/gaywater_forever
+  required_reagents = list(/datum/reagent/medicine/gaywater = 1, /datum/reagent/water = 1)
+  results = list(/datum/reagent/medicine/gaywater = 2)
+  reaction_flags = REACTION_INSTANT
+  reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER

--- a/troutstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/troutstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -1,0 +1,13 @@
+/datum/chemical_reaction/reagent_explosion/gay_potassium_explosion
+	required_reagents = list(/datum/reagent/medicine/gaywater = 1, /datum/reagent/potassium = 1)
+	strengthdiv = 15 // a bit weaker than normal potassium explosion
+
+/datum/chemical_reaction/reagent_explosion/gay_potassium_explosion/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
+	var/turf/center = get_turf(holder.my_atom)
+	var/range = created_volume/5
+	for(var/turf/T in RANGE_TURFS(range, center))
+		T.add_filter("gay_explosion_pink", 10, color_matrix_filter(COLOR_FADED_PINK))
+		for(var/mob/living/M in T)
+			playsound(M, 'troutstation/sound/misc/gay.ogg', 100, FALSE)
+			M.reagents.add_reagent(/datum/reagent/medicine/gaywater, 25)
+	default_explode(holder, created_volume, modifier, strengthdiv, FALSE)


### PR DESCRIPTION

## About The Pull Request
Gay water now interacts with Potassium and explodes. It also turns squares around the explosion pink.
Also, gay water touching water now makes the water gay water. gay water.

## Why It's Good For The Game
giving more things to do with gay water i guess

## Changelog
:cl:
add: gay water explosion
add: gay water replication
/:cl:
