### PR TITLE
Examining someone with gay water in them tells you

### DIFF
--- a/troutstation/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/troutstation/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -51,3 +51,8 @@
 	if(prob(5))
 		affected_mob.say(pick("bable", "beble", "bible", "boble", "booble", "babie", "bebie", "bibie", "bobie", "bubie", "boobie"))
 		sleep(100)
+
+/mob/living/carbon/examine(mob/user)
+	. = ..()
+	if(reagents.has_reagent(/datum/reagent/medicine/gaywater, needs_metabolizing = TRUE))
+		. += span_notice("[p_They()] [p_are()] gay!")


### PR DESCRIPTION

## About The Pull Request
just makes it so if you examine someone with gay water in their system, you Know now. theyre gay

## Why It's Good For The Game
gay

## Changelog
:cl:
add: Gay water detectable in mobs upon examination
/:cl:
