### PR TITLE
Rufran plush now grows when using normal injectors

### DIFF
--- a/troutstation/code/datums/components/crafting/entertainment.dm
+++ b/troutstation/code/datums/components/crafting/entertainment.dm
@@ -3,7 +3,7 @@
 	result = /obj/item/toy/plush/rufran
 	time = 1 SECONDS
 	reqs = list(
-		/obj/item/dnainjector/gigantism = 1,
+		/obj/item/dnainjector = 1,
 		/obj/item/toy/plush/moth = 1
 		)
 	category = CAT_ENTERTAINMENT

--- a/troutstation/code/game/objects/items/plushes.dm
+++ b/troutstation/code/game/objects/items/plushes.dm
@@ -79,10 +79,11 @@
 	name = "rufran plushie"
 	desc = "An adorable stuffed toy that resembles a moth and a bird. You feel like it looked smaller earlier."
 	icon_state = "plushie_rufran"
+	squeak_override = list('sound/mobs/humanoids/moth/scream_moth.ogg'=1)
 	var/size = RUFRAN_NORMAL_SIZE
 
-/obj/item/toy/plush/rufran/attackby(obj/item/dnainjector/gigantism/serum, mob/user, list/modifiers, list/attack_modifiers)
-	if(serum.used==FALSE && istype(serum, /obj/item/dnainjector/gigantism) && size < RUFRAN_GIGANTIC_SIZE)
+/obj/item/toy/plush/rufran/attackby(obj/item/dnainjector/serum, mob/user, list/modifiers, list/attack_modifiers)
+	if((serum.used==FALSE && size < RUFRAN_GIGANTIC_SIZE && /datum/mutation/gigantism in serum.add_mutations) || (serum.used==FALSE && size < RUFRAN_GIGANTIC_SIZE && serum.add_mutations[1].name == "Gigantism")) // holy shit if you can make this cleaner PLEASE
 		to_chat(user, span_notice("You inject [src] with the gigantism serum!"))
 		size += RUFRAN_SIZE_INCREMENT
 		AddElement(/datum/element/item_scaling, size, size)


### PR DESCRIPTION

## About The Pull Request
before the rufran plush could only be activated when using the admin spawned dna injectors. now it works with naturally made injectors (mutators/activators)
also adjusted crafting recipe to use any injector because get fucked if im figuring out how to make sure that one is Specifically Gigantism 

## Why It's Good For The Game
actually makes shit i wrote useable

## Changelog
:cl:
fix: fixed rufran plush activation
/:cl:
