### PR TITLE
Gaywater explosion colors items, now cleanable

### DIFF
--- a/troutstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/troutstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -4,10 +4,20 @@
 
 /datum/chemical_reaction/reagent_explosion/gay_potassium_explosion/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/turf/center = get_turf(holder.my_atom)
-	var/range = created_volume/5
-	for(var/turf/T in RANGE_TURFS(range, center))
-		T.add_filter("gay_explosion_pink", 10, color_matrix_filter(COLOR_FADED_PINK))
-		for(var/mob/living/M in T)
+	var/range = created_volume/6
+	var/include_flags = INCLUDE_HELD|INCLUDE_ACCESSORIES|INCLUDE_POCKETS
+
+	for (var/turf/T in RANGE_TURFS(range, center))
+		T.add_atom_colour("#ff99fc",WASHABLE_COLOUR_PRIORITY)
+
+		for (var/mob/living/M in T)
 			playsound(M, 'troutstation/sound/misc/gay.ogg', 100, FALSE)
 			M.reagents.add_reagent(/datum/reagent/medicine/gaywater, 25)
+
+			for (var/obj/item/gayitem in M.get_equipped_items(include_flags))
+				gayitem.add_atom_colour("#ff99fc", WASHABLE_COLOUR_PRIORITY)
+
+		for (var/obj/gaything in T)
+			gaything.add_atom_colour("#ff99fc", WASHABLE_COLOUR_PRIORITY)
+
 	default_explode(holder, created_volume, modifier, strengthdiv, FALSE)


### PR DESCRIPTION

## About The Pull Request
Changes how gaywater explosions affect things. Items in the explosion range (now slightly smaller) become gay, clothes worn and items held by those in range become gay, and they're now cleanable (tiles included).
The cleanbot will not clean them, but it also doesn't clean tiles affected by colorful reagent anyway.

## Why It's Good For The Game
Makes gaywater explosion slightly more obnoxious, but makes it fixable. Making it work as originally intended, really.

## Changelog
:cl:
add: Gaywater explosion now affects items
fix: Tiles affected by gaywater explosion now cleanable
/:cl:
