### PR TITLE
increase gaywater overdose threshold

### DIFF
--- a/troutstation/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/troutstation/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -17,7 +17,7 @@
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen. But gay."
 	color = "#ff99fcfF"
 	taste_description = "gay"
-	overdose_threshold = 30
+	overdose_threshold = 75 // one and a half glasses to "balance" it
 	var/cooling_temperature = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS
 	default_container = /obj/item/reagent_containers/cup/glass/waterbottle


### PR DESCRIPTION

## About The Pull Request
Before you could drink one glass of gaywater and you would overdose and turn pink. Now it takes a glass and a half. 
It's harder to be gay now.

## Why It's Good For The Game
Makes it harder to accidentally overdose. If the scrubbers overflow you are less likely to immediately overdose, though I do not know how much is put into a character anyway.

## Changelog
:cl:
balance: Rebalanced gaywater overdose threshold
/:cl:
