### PR TITLE
Changeloggening Part 1

### DIFF
--- a/html/changelogs/archive/2025-03.yml
+++ b/html/changelogs/archive/2025-03.yml
@@ -448,6 +448,9 @@
   tralezab:
   - balance: The cargo console now has a delay to express orders (renamed to autodelivery)
 2025-03-17:
+  Cirrial:
+  - troutstation: true
+  - rscadd: Added scugs
   Absolucy:
   - bugfix: Toxins no longer damage your liver if you are immune to toxins anyways.
   ArcaneMusic:

--- a/html/changelogs/archive/2025-04.yml
+++ b/html/changelogs/archive/2025-04.yml
@@ -381,6 +381,11 @@
   vinylspiders:
   - bugfix: removed the gap from the quirks page menu items
 2025-04-14:
+  Cirrial:
+  - troutstation: true
+  - rscadd: Anteaters.
+  - rscadd: Added skiff icons
+  - image: Added skiff icons
   Bisar:
   - code_imp: Subsystems that are meant to represent a network in-game have been moved
       into their own category inside the codebase.
@@ -615,6 +620,11 @@
   - bugfix: Objects crafted from lavaland fauna materials (bone, sinew, hide) are
       now fireproof and lavaproof. And also reinforced fishing lines.
 2025-04-21:
+  Guffy:
+  - troutstation: true
+  - rscadd: maddie plush
+  - rscadd: VOX sounds
+  - rscadd: Added two AI displays.
   FlufflesTheDog:
   - bugfix: Passive modsuit modules (radiation protection, welding protection, etc)
       should work reliably again.
@@ -645,6 +655,11 @@
   jlsnow301:
   - bugfix: Fixed more bugs in tgui-say. Admin chat shouldn't be cut off any more.
 2025-04-22:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added new food category
+  - rscadd: Added 5 new foods
+  - rscadd: Added 1 new drink
   DaCoolBoss:
   - spellcheck: Removed 5 random wizard names. Added 6 to replace them.
   EmptyLullaby:
@@ -693,6 +708,9 @@
   - balance: Part-Mart vending machines now have mousetraps, spare screwdrivers and
       rifle stocks in their contraband section.
 2025-04-24:
+  Cirrial:
+  - troutstation: true
+  - rscadd: Added coconut, thanks to Guffy for sprites
   Ghommie:
   - qol: You can now interact with held mobs in more ways beside wearing them.
   - bugfix: Fixed moonfish eggs appearing like huge errors inside aquariums.
@@ -707,6 +725,10 @@
       them FAST. Report if they are not FAST.
   - bugfix: Fixed a bluescreen caused when moving a tgui window with a tooltip open.
 2025-04-25:
+  Guffy:
+  - troutstation: true
+  - rscadd: Ionian dialect effect to food
+  - rscadd: cork cat that applies Ionian dialect
   Cirrial:
   - qol: Added some help for abductors if they get a weird half-machine test subject
       in their ship.
@@ -766,6 +788,10 @@
   zxaber:
   - bugfix: Fixed a visual bug with cyborg tools that are able to carry items.
 2025-04-27:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added more food from Io
+  - qol: Changed pavlova to be Io food.
   Cirrial:
   - bugfix: Made it so minebot commands don't talk about dumping ore when you're toggling
       the lights.

--- a/html/changelogs/archive/2025-05.yml
+++ b/html/changelogs/archive/2025-05.yml
@@ -1,4 +1,8 @@
 2025-05-01:
+  Guffy:
+  - troutstation: true
+  - rscadd: some word replacements for io
+  - rscdel: some word replacements for io
   Ezel/Improvedname, JohnFulpWillard:
   - balance: Cult daggers boomerang back to non-cultists who throw it.
   - balance: Flagellant's robes crushes non-cultists with gravity instead of forcing
@@ -42,6 +46,16 @@
   - bugfix: throwing items on the same tile as you will make a sound again
   - bugfix: fixes bane element not working if it was used by a weapon without a wielder
 2025-05-02:
+  ArchytasBird:
+  - troutstation: true
+  - rscadd: relics now have a procedurally generated web of effects that can happen when introduced to various stimuli
+  - rscadd: relic cargo order to order more relics once the station is picked clean
+  - rscadd: relic pinpointer to monitor relic states & assist in finding fruitful stimuli
+  - rscadd: relic pinpointer to science wardrobe, crafting and autolathe recepies
+  - image: plushie_archy
+  - code_imp: small chance for any relic to have the plushie_archy sprite applied
+  - refactor: minor extension to how relics handle variants
+  - admin: added some admin alerts for potentially disastrous relic effects
   ArrisFairburne:
   - code_imp: removed non-functional ID saving functions
   Goat:
@@ -186,6 +200,15 @@
   TealSeer:
   - bugfix: roundstart photocopiers should no longer be empty on some maps
 2025-05-08:
+  ArchytasBird:
+  - troutstation: true
+  - rscadd: Relic Analyzer to handle activating and displaying relic information, as well as contributing research points for every scanned relic node.
+  - rscadd: Relic Pinpointers have a "sweep" scan mode that will display the nearest relic (activated or not).
+  - rscadd: Relics are listening...
+  - rscadd: Relics are hungry...
+  - rscadd: Relics have knowledge to share...
+  - qol: Relic nodes are now weighted (all equal odds atm)
+  - rscdel: Relic Pinpointers no longer display relic information
   Bisar:
   - image: Animations have been added to inserting/removing items from machines, and
       to inserting things into containers that are not on your person.
@@ -278,6 +301,12 @@
   vinylspiders:
   - bugfix: stops snails from clogging up CI
 2025-05-12:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added Skiff hologram for AI
+  - rscadd: Io foods
+  - qol: Sprinkles orderable from Produce Orders Console
+  - refactor: misnamed folder
   Jacquerel:
   - balance: Regal Rats can now grab mice out of disposal bins, and no longer spawn
       them with the Riot ability.
@@ -378,6 +407,9 @@
   TealSeer:
   - bugfix: fixed cross-server newscaster functionality
 2025-05-17:
+  Guffy:
+  - troutstation: true
+  - sound: Modified frog sound.
   Absolucy:
   - bugfix: False walls properly smooth with objects now, such as other false walls.
   Holoo-1:
@@ -782,6 +814,9 @@
   - spellcheck: Stations in the Spinward Sector have reported malfunctioning AIs swearing
       fealty to the dead god Ratvar.
 2025-05-30:
+  Cirrial:
+  - troutstation: true
+  - rscadd: Anteaters can now see if the foods are snout-sized or not. So can chefs.
   00-Steven:
   - refactor: Refactored the folder/biscuit interaction chain. Please report any issues.
   - bugfix: Picking up paper into a folder/biscuit by clicking on the paper with it

--- a/html/changelogs/archive/2025-06.yml
+++ b/html/changelogs/archive/2025-06.yml
@@ -287,6 +287,18 @@
   - bugfix: map exported APC's now locate the terminals under them & attach to it
       thus enabling charging & stuff
 2025-06-13:
+  ArchytasBird:
+  - troutstation: true
+  - rscadd: relics can table things
+  - balance: relic blood-lust no longer juice-boxes
+  - bugfix: relic pinpointer general scanning now works
+  - qol: adjusted colors to be more readable
+  - qol: adjusted various span formats to better display hazards
+  - qol: paint condition given a clearer description
+  - bugfix: swapped oview with view - this means standing on a relic is no longer safe
+  - balance: relics now have a (for now) short ban-list of some more disruptive round-ending spawns
+  - balance: relics have a higher minimum reaction time so players have time to respond to threats more
+  - rscadd: \"very_dangerous\" bool to relics to remove current and future guardrails for admeme abuse
   00-Steven:
   - bugfix: The static from holocalls no longer stays even after exiting the holocall.
   Absolucy:

--- a/html/changelogs/archive/2025-07.yml
+++ b/html/changelogs/archive/2025-07.yml
@@ -724,6 +724,10 @@
   - balance: Ice demon/ice demon cube afterimages can now be walked through by players
   - bugfix: Sphere MODule bombs now aggro basicmobs hit by their explosions
 2025-07-30:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added Gay Water
+  - rscadd: Added Gay Water Cooler
   Bisar:
   - qol: Power cells and megacells now take much less time to print.
   - balance: Power cells now take the base-item time-to-print ( 10 seconds -> 3.2
@@ -741,6 +745,9 @@
       called allow_custom now determines whether the machine can be chosen when screwdrivering
       the circuit board
 2025-07-31:
+  Guffy:
+  - troutstation: true
+  - rscadd: 35% chance for water coolers to be gay.
   Aliceee2ch:
   - bugfix: Tier 3 cyber heart now prevents bleeding as intended
   Bisar:

--- a/html/changelogs/archive/2025-08.yml
+++ b/html/changelogs/archive/2025-08.yml
@@ -61,6 +61,9 @@
   subject217:
   - spellcheck: fixed a typo in the operative bomb implant manual
 2025-08-03:
+  Guffy:
+  - troutstation: true
+  - code_imp: altered reagent type of gay water
   SmArtKar:
   - qol: Monster cores now display above corpses when dropped
   Thunder12345:
@@ -125,6 +128,10 @@
   - code_imp: cleaned up closet see through code. It's documented & slightly faster
       performance wise
 2025-08-07:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added water cooler phobia
+  - rscadd: Added random speech for gay water coolers
   Arturlang:
   - code_imp: action's now pass down the clicker via the first arg of Trigger()
   - code_imp: antagonist ui_act now ensures that the owners of the antag datum thesmelves
@@ -151,6 +158,9 @@
   - bugfix: Fixed unrestricted access overlays not showing up on windoors.
   - bugfix: Fixed blood/glass floor glow going over objects
 2025-08-08:
+  Guffy:
+  - troutstation: true
+  - rscadd: gay water overdose
   Arturlang:
   - bugfix: ghosts can't buy heretic powers
   Melbert:
@@ -371,6 +381,12 @@
   plsleavemealon:
   - rscadd: Adds a new bounty app to the PDA allowing you to remotely check your bounties
 2025-08-15:
+  ArchytasBird:
+  - troutstation: true
+  - rscadd: Science order for relics
+  - bugfix: tabling should work
+  - bugfix: organ harvesting effect on relics updated to current safe tm method
+  - refactor: normal relic orders come in a dumpster
   EnterTheJake:
   - balance: Uplink price on the suppressor has been lowered from 3 to 1 TC.
   Ezel:
@@ -474,6 +490,9 @@
   - map: Adds an External Security Camera to the Starboard Vault Wall overlooking
       the AI Upload on Nebulastation
 2025-08-20:
+  Guffy:
+  - troutstation: true
+  - bugfix: fixed ralsei plush not being in the game
   Cameron-The-Raven:
   - bugfix: Brains will no longer runtime when owner-less
   panvxv:

--- a/html/changelogs/archive/2025-09.yml
+++ b/html/changelogs/archive/2025-09.yml
@@ -44,6 +44,10 @@
   - bugfix: Fixed shuttle cleanup code bypassing move contents of turfs
   - bugfix: Fixed tram crossing signals bypassing north and east direction checks
 2025-09-03:
+  Guffy:
+  - troutstation: true
+  - rscadd: gay water explosion
+  - rscadd: gay water replication
   Rhials:
   - bugfix: Pirates can sell minerals and other cargo exports on their bounty pad
       again.
@@ -99,6 +103,11 @@
   subject217:
   - spellcheck: fixed a typo in the admin message about achievements cleanup
 2025-09-05:
+  Guffy:
+  - troutstation: true
+  - rscadd: rufran plush
+  - rscadd: bowling ball
+  - rscadd: Gay water detectable in mobs upon examination
   Ezel:
   - bugfix: fixes kitchen plumbing not being connected to any water source
   - map: Adds and expands plumbing systems around metastation
@@ -328,6 +337,9 @@
   - bugfix: Imperium monk outfits now hold the true list of chaplain suit storage
       items, and not just a limited list.
 2025-09-12:
+  Guffy:
+  - troutstation: true
+  - bugfix: fixed rufran plush activation
   Aliceee2ch:
   - map: Added shutters in Cargo bay on every station.
   - map: Added firelocks on lower Cargo staircase on TramStation. Also added space
@@ -693,6 +705,10 @@
   timothymtorres:
   - qol: Objects that are EMP-proof will now have it appear as a examine tag desc
 2025-09-29:
+  Kaltren:
+  - troutstation: true
+  - rscadd: Anteater Mutation Toxin now exists as a reagent. It cannot show up in random recipes.
+  - rscadd: Injecting ants into a Green Slime Extract now produces Anteater Mutation Toxin.
   ArcaneMusic:
   - rscdel: You can no longer obtain an emagged fishing portal board from treasure
       chests. You can still, however, emag fishing portals.

--- a/html/changelogs/archive/2025-10.yml
+++ b/html/changelogs/archive/2025-10.yml
@@ -762,6 +762,9 @@
   - map: CATWALK - AI Upload - Re-balanced to have extra protection similar to every
       other map, layout tweaks for style as well as clearer layout of modules
 2025-10-24:
+  TS!Cirrial:
+  - add: testing something for later. todo - gather up changes and
+      write script to shove them into changelog at long fucking last
   Aliceee2ch:
   - balance: Minimal hacked APC amount for purchasing doomsday module was lowered
       from 15 to 10.

--- a/html/changelogs/archive/2025-10.yml
+++ b/html/changelogs/archive/2025-10.yml
@@ -1,4 +1,7 @@
 2025-10-01:
+  Guffy:
+  - troutstation: true
+  - image: added new ui
   Iajret:
   - bugfix: Fixed an edge case of mineral turfs being generated with 0 amount of ore
       in it.
@@ -534,6 +537,20 @@
   grungussuss:
   - qol: item offers now persist when pulling
 2025-10-17:
+  ArchytasBird:
+  - troutstation: true
+  - rscadd: 'relics have a few new interactions: mouseover'
+  - rscadd: 'relics have a few new nodes: embed, contraband, cloaking'
+  - balance: relics can be changed to be useable as a tool type via implements node
+  - balance: the language node now sets someone's understanding instead of strictly adding
+  - balance: emp effects activate relics
+  - bugfix: relics can hear stuff again
+  - bugfix: tabling now teleports the relic to the table
+  - spellcheck: fixed a few typos
+  Guffy:
+  - troutstation: true
+  - rscadd: Gaywater explosion now affects items
+  - bugfix: Tiles affected by gaywater explosion now cleanable
   Aliceee2ch:
   - qol: Jaws of Recovery can be worn on medical MODSuit suit storage now.
   - rscadd: Added modified Jaws of Recovery and recipe for them. Made from regular
@@ -556,6 +573,9 @@
   - bugfix: Females wearing either a yukata or kimono no longer have holes in their
       clothes.
 2025-10-19:
+  Guffy:
+  - troutstation: true
+  - rscadd: Hugs-The-Moths plushie
   ArchBTW:
   - bugfix: removes fov cone (oversight) with medieval pirate helmet
   Arturlang:
@@ -641,6 +661,9 @@
   tttruancy:
   - balance: Plastic flaps now resist heat better
 2025-10-21:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added crushable Cydonia plush, and vending machine plushes
   Aliceee2ch:
   - spellcheck: Minor grammar fix for extinguishers
   Melbert:
@@ -762,9 +785,6 @@
   - map: CATWALK - AI Upload - Re-balanced to have extra protection similar to every
       other map, layout tweaks for style as well as clearer layout of modules
 2025-10-24:
-  TS!Cirrial:
-  - add: testing something for later. todo - gather up changes and
-      write script to shove them into changelog at long fucking last
   Aliceee2ch:
   - balance: Minimal hacked APC amount for purchasing doomsday module was lowered
       from 15 to 10.
@@ -855,6 +875,9 @@
   - sound: added sounds for utility headwear
   - sound: surgery caps use cloth sounds now
 2025-10-29:
+  Guffy:
+  - troutstation: true
+  - rscadd: youtube poop announcer station trait
   Aliceee2ch:
   - spellcheck: Birdshot plaque was decomissioned and replaced on Catwalk.
   Fghj240:

--- a/html/changelogs/archive/2025-11.yml
+++ b/html/changelogs/archive/2025-11.yml
@@ -151,6 +151,9 @@
       refactored internally. Please make an issue report if things relating to them
       start behaving strangely.
 2025-11-05:
+  Guffy:
+  - troutstation: true
+  - sound: added ambient track for the detective's office
   Arturlang:
   - rscadd: adds some missing info to the heretic UI related to the heretic aura,
       codex cicatrix and moon amulet and it's effects
@@ -253,6 +256,9 @@
   - bugfix: fixes an oversight where the wardrobe system tries to delete modsuit parts
       when stashing the modsuit
 2025-11-09:
+  Guffy:
+  - troutstation: true
+  - rscadd: Added new organ instrument, The Organ (Eek!)
   Cirrial:
   - bugfix: Extreme Medicine Allergy quirk will no longer lead to you being allergic
       to nothing
@@ -282,6 +288,10 @@
   - bugfix: Grasp of Lock can no longer yank down your jumpsuit unless it is capable
       of being adjusted.
   - code_imp: Cleans up some leftover mentions of 'knock' in Lock code.
+2025-11-10:
+  Guffy:
+  - troutstation: true
+  - rscadd: Lehto plush
 2025-11-11:
   Aliceee2ch:
   - map: Removed two over-strong turrets on interdyne pirate ship.
@@ -380,6 +390,11 @@
   timothymtorres:
   - code_imp: Add correct code documentation for object flags
 2025-11-14:
+  Guffy:
+  - troutstation: true
+  - rscadd: Watermelon mutation "gaywatermelon"
+  - rscadd: Gaywatermelon armor
+  - sound: Attacking with a gaywater cooler jug is now gay also
   Aliceee2ch:
   - spellcheck: Flash message now starts with a capital letter.
   ArchBTW:
@@ -509,6 +524,9 @@
   - qol: Welding protection now prevents Maintenance Adapted eyes from burning in
       the light.
 2025-11-19:
+  Guffy:
+  - troutstation: true
+  - sound: added 4 "gay" sounds that can play when you are gay
   Hatterhat:
   - bugfix: Alien welders, as befitting their nature of being Wacky Advanced Tools,
       no longer sear your eyeballs if you don't have eye protection.
@@ -657,6 +675,9 @@
   - rscadd: Added mapping helpers for cent_officer and cent_specops access
   - map: Changed access on the administrative office doors (cent_officer)
 2025-11-23:
+  Guffy:
+  - troutstation: true
+  - balance: Rebalanced gaywater overdose threshold
   EEASAS:
   - bugfix: Fixes a few disposal pipes on CatwalkStation. Read the PR!
   - bugfix: Fixes Icebox's comms agent ruin having generic documents, not the secret
@@ -690,6 +711,9 @@
   ibexgoetia:
   - image: Resprited the Plague Doctor's costume.
 2025-11-25:
+  Guffy:
+  - troutstation: true
+  - qol: Every loadout item is re-nameable
   Cat:
   - balance: Bartender's wardrobe vendor starts with a service plumbing constructor
   FalloutFalcon:
@@ -707,6 +731,9 @@
   vinylspiders, Wallemations:
   - image: space heaters got a model replacement, from stick heaters to box heaters
 2025-11-26:
+  Guffy:
+  - troutstation: true
+  - refactor: cleans up gay sfx
   Aliceee2ch:
   - image: Various beakers now have own inhands sprites.
   JohnFulpWillard:
@@ -751,6 +778,11 @@
   - bugfix: fixes a bug that caused you to need to wear shoes in order to gain any
       defensive benefit from the sleeping carp martial art style
 2025-11-28:
+  Guffy:
+  - troutstation: true
+  - rscadd: New mob, Skitterers
+  - rscadd: Gay escape shuttle
+  - rscadd: Added new holodeck option, Break Room
   Bisar:
   - code_imp: All (Brute|Burn|Fire|Tox|Oxy|Organ|Stamina)(Loss) procs now use snake_case,
       in-line with the STYLE guide. Underscores rule!
@@ -789,6 +821,9 @@
   ezel:
   - balance: You can no longer print soup pots
 2025-11-30:
+  Guffy:
+  - troutstation: true
+  - rscadd: custom suicide using gay watermelon
   Aliceee2ch:
   - image: Added more inhands sprite for welders, aswell as upgrading some of them.
   Cat:

--- a/html/changelogs/archive/2025-12.yml
+++ b/html/changelogs/archive/2025-12.yml
@@ -174,6 +174,9 @@
   - balance: The MODsuit equipment techweb node has been split in two, with an offshoot
       for civilian MODules.
 2025-12-05:
+  Guffy:
+  - troutstation: true
+  - bugfix: realigned door on the gay escape shuttle
   Aliceee2ch:
   - image: Most of mapping spawner icons were updated to match latest version of sprites.
   ArchBTW:
@@ -296,6 +299,9 @@
   - rscadd: Added a new set of chaplain armour based on the generic heretic robes
       unavailable since the path rework.
 2025-12-09:
+  Guffy:
+  - troutstation: true
+  - rscadd: Picnic blanket tile
   Aliceee2ch:
   - image: Added 2 new contraband and 1 new official posters.
   Fghj240:
@@ -333,6 +339,9 @@
   - admin: Multikeying Notice Messages have taken on a new form factor but should
       still furnish the same information.
 2025-12-10:
+  Guffy:
+  - troutstation: true
+  - rscadd: Skitterers now steal items laying around
   ArcaneMusic:
   - bugfix: Plasma sheets are once again immune to market elasticity, selling for
       a static 80 credits each yet again.

--- a/tgui/packages/tgui/interfaces/Changelog.jsx
+++ b/tgui/packages/tgui/interfaces/Changelog.jsx
@@ -44,7 +44,7 @@ const icons = {
   wip: { icon: 'hammer', color: 'orange' },
 };
 
-const HACKY_TROUTSTATION_PREFIX = 'TS!';
+const TROUTSTATION_IDENT = 'troutstation';
 
 export class Changelog extends Component {
   constructor(props) {
@@ -308,26 +308,41 @@ export class Changelog extends Component {
             <Box ml={3}>
               {Object.entries(authors).map(([name, changes]) => {
                 let isTroutstationEntry = false;
-                if (name.startsWith(HACKY_TROUTSTATION_PREFIX)) {
-                  name = name.replace(HACKY_TROUTSTATION_PREFIX, '');
-                  isTroutstationEntry = true;
-                }
+                changes.map((change) => {
+                  const changeType = Object.keys(change)[0];
+                  if (isTroutstationEntry) {
+                    // already figured it out
+                    return;
+                  }
+                  if (changeType === TROUTSTATION_IDENT) {
+                    isTroutstationEntry = true;
+                    return;
+                  }
+                });
                 return (
                   <Fragment key={name}>
-                    <h4>{name} changed:</h4>
+                    <h4
+                      className={
+                        isTroutstationEntry
+                          ? 'Changelog__Cell__Troutstation'
+                          : ''
+                      }
+                    >
+                      {name} changed:
+                    </h4>
                     <Box ml={3}>
                       <Table>
                         {changes.map((change) => {
                           const changeType = Object.keys(change)[0];
+                          if (changeType === TROUTSTATION_IDENT) {
+                            return; // do not actually display anything
+                          }
                           return (
                             <Table.Row key={changeType + change[changeType]}>
                               <Table.Cell
                                 className={classes([
                                   'Changelog__Cell',
                                   'Changelog__Cell--Icon',
-                                  isTroutstationEntry
-                                    ? 'Changelog__Cell__Troutstation'
-                                    : '',
                                 ])}
                               >
                                 <Icon

--- a/tgui/packages/tgui/interfaces/Changelog.jsx
+++ b/tgui/packages/tgui/interfaces/Changelog.jsx
@@ -44,6 +44,8 @@ const icons = {
   wip: { icon: 'hammer', color: 'orange' },
 };
 
+const HACKY_TROUTSTATION_PREFIX = 'TS!';
+
 export class Changelog extends Component {
   constructor(props) {
     super(props);
@@ -304,44 +306,61 @@ export class Changelog extends Component {
         .map(([date, authors]) => (
           <Section key={date} title={dateformat(date, 'd mmmm yyyy', true)}>
             <Box ml={3}>
-              {Object.entries(authors).map(([name, changes]) => (
-                <Fragment key={name}>
-                  <h4>{name} changed:</h4>
-                  <Box ml={3}>
-                    <Table>
-                      {changes.map((change) => {
-                        const changeType = Object.keys(change)[0];
-                        return (
-                          <Table.Row key={changeType + change[changeType]}>
-                            <Table.Cell
-                              className={classes([
-                                'Changelog__Cell',
-                                'Changelog__Cell--Icon',
-                              ])}
-                            >
-                              <Icon
-                                color={
-                                  icons[changeType]
-                                    ? icons[changeType].color
-                                    : icons.unknown.color
-                                }
-                                name={
-                                  icons[changeType]
-                                    ? icons[changeType].icon
-                                    : icons.unknown.icon
-                                }
-                              />
-                            </Table.Cell>
-                            <Table.Cell className="Changelog__Cell">
-                              {change[changeType]}
-                            </Table.Cell>
-                          </Table.Row>
-                        );
-                      })}
-                    </Table>
-                  </Box>
-                </Fragment>
-              ))}
+              {Object.entries(authors).map(([name, changes]) => {
+                let isTroutstationEntry = false;
+                if (name.startsWith(HACKY_TROUTSTATION_PREFIX)) {
+                  name = name.replace(HACKY_TROUTSTATION_PREFIX, '');
+                  isTroutstationEntry = true;
+                }
+                return (
+                  <Fragment key={name}>
+                    <h4>{name} changed:</h4>
+                    <Box ml={3}>
+                      <Table>
+                        {changes.map((change) => {
+                          const changeType = Object.keys(change)[0];
+                          return (
+                            <Table.Row key={changeType + change[changeType]}>
+                              <Table.Cell
+                                className={classes([
+                                  'Changelog__Cell',
+                                  'Changelog__Cell--Icon',
+                                  isTroutstationEntry
+                                    ? 'Changelog__Cell__Troutstation'
+                                    : '',
+                                ])}
+                              >
+                                <Icon
+                                  color={
+                                    icons[changeType]
+                                      ? icons[changeType].color
+                                      : icons.unknown.color
+                                  }
+                                  name={
+                                    icons[changeType]
+                                      ? icons[changeType].icon
+                                      : icons.unknown.icon
+                                  }
+                                />
+                              </Table.Cell>
+                              <Table.Cell
+                                className={classes([
+                                  'Changelog__Cell',
+                                  isTroutstationEntry
+                                    ? 'Changelog__Cell__Troutstation'
+                                    : '',
+                                ])}
+                              >
+                                {change[changeType]}
+                              </Table.Cell>
+                            </Table.Row>
+                          );
+                        })}
+                      </Table>
+                    </Box>
+                  </Fragment>
+                );
+              })}
             </Box>
           </Section>
         ));

--- a/tgui/packages/tgui/styles/interfaces/Changelog.scss
+++ b/tgui/packages/tgui/styles/interfaces/Changelog.scss
@@ -9,5 +9,10 @@
     &--Icon {
       width: 25px;
     }
+
+    &__Troutstation {
+      background-color: #295982;
+      color: #ffffff;
+    }
   }
 }

--- a/tgui/packages/tgui/styles/interfaces/Changelog.scss
+++ b/tgui/packages/tgui/styles/interfaces/Changelog.scss
@@ -13,6 +13,9 @@
     &__Troutstation {
       background-color: #295982;
       color: #ffffff;
+      margin: 2px;
+      padding: 3px;
+      border: 2px dashed #417db1;
     }
   }
 }


### PR DESCRIPTION
## About The Pull Request

Finally there is a way to display Troutstation specific changes woven into the main changelog. Laboriously I've spliced in every merged PR from server begin to now.

The work is not finished because I don't have this process fully automated yet, but I'll see what happens when the now re-enabled changelog generation stuff kicks into action and what script I can write to handle merging it into the existing changelogs.

## Why It's Good For The Game

creidt ur devs

## Changelog

:cl:
add: Added Troutstation changelogs (highlighted in the main changelog).
/:cl: