### PR TITLE
Job Estimator

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -803,3 +803,5 @@
 	min_val = 0
 
 /datum/config_entry/flag/fishing
+
+/datum/config_entry/flag/show_job_estimation // Troutstation Edit

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -187,6 +187,9 @@ SUBSYSTEM_DEF(ticker)
 
 					var/datum/job/J = prefs.get_highest_priority_job()
 					var/title = J.title
+					if(!J)
+						pickedJobs["Jobless"] += 1
+						continue
 					if(player.ready == PLAYER_READY_TO_PLAY)
 						pickedJobs[title] += 1
 				for(var/t, v in pickedJobs)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -186,10 +186,10 @@ SUBSYSTEM_DEF(ticker)
 						continue
 
 					var/datum/job/J = prefs.get_highest_priority_job()
-					var/title = J.title
 					if(!J)
 						pickedJobs["Jobless"] += 1
 						continue
+					var/title = J.title
 					if(player.ready == PLAYER_READY_TO_PLAY)
 						pickedJobs[title] += 1
 				for(var/t, v in pickedJobs)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -176,6 +176,7 @@ SUBSYSTEM_DEF(ticker)
 			sortTim(players, GLOBAL_PROC_REF(cmp_text_asc))
 
 			if(CONFIG_GET(flag/show_job_estimation))
+				var/pickedJobs[0]
 				for(var/ckey in players)
 					var/mob/dead/new_player/player = players[ckey]
 					var/datum/preferences/prefs = player.client?.prefs
@@ -184,15 +185,12 @@ SUBSYSTEM_DEF(ticker)
 					if(!prefs.read_preference(/datum/preference/toggle/ready_job))
 						continue
 
-					var/display = player.client?.holder?.fakekey || ckey
-
 					var/datum/job/J = prefs.get_highest_priority_job()
-					if(!J)
-						player_ready_data += "* [display] forgot to pick a job!"
-						continue
 					var/title = J.title
 					if(player.ready == PLAYER_READY_TO_PLAY)
-						player_ready_data += "* [display] as [title]"
+						pickedJobs[title] += 1
+				for(var/t, v in pickedJobs)
+					player_ready_data += "[t]: [v]"
 
 				if(length(player_ready_data))
 					player_ready_data.Insert(1, "------------------")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -47,6 +47,8 @@ SUBSYSTEM_DEF(ticker)
 	var/totalPlayersReady = 0
 	/// Num of ready admins, used for pregame stats on statpanel (only viewable by admins)
 	var/total_admins_ready = 0
+	/// Troutstation Edit: Data for lobby player stat panels during the pre-game.
+	var/list/player_ready_data = list() // Troutstation Edit
 
 	var/queue_delay = 0
 	var/list/queued_players = list() //used for join queues when the server exceeds the hard population cap
@@ -160,11 +162,43 @@ SUBSYSTEM_DEF(ticker)
 			totalPlayers = LAZYLEN(GLOB.new_player_list)
 			totalPlayersReady = 0
 			total_admins_ready = 0
+			player_ready_data.Cut() // Troutstation Edit
+			var/list/players = list() // Troutstation Edit
+
 			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
 					if(player.client?.holder)
 						++total_admins_ready
+					/// Troutstation Edit Start
+					players[player.key] = player
+
+			sortTim(players, GLOBAL_PROC_REF(cmp_text_asc))
+
+			if(CONFIG_GET(flag/show_job_estimation))
+				for(var/ckey in players)
+					var/mob/dead/new_player/player = players[ckey]
+					var/datum/preferences/prefs = player.client?.prefs
+					if(!prefs)
+						continue
+					if(!prefs.read_preference(/datum/preference/toggle/ready_job))
+						continue
+
+					var/display = player.client?.holder?.fakekey || ckey
+
+					var/datum/job/J = prefs.get_highest_priority_job()
+					if(!J)
+						player_ready_data += "* [display] forgot to pick a job!"
+						continue
+					var/title = J.title
+					if(player.ready == PLAYER_READY_TO_PLAY)
+						player_ready_data += "* [display] as [title]"
+
+				if(length(player_ready_data))
+					player_ready_data.Insert(1, "------------------")
+					player_ready_data.Insert(1, "Job Estimation:")
+					player_ready_data.Insert(1, "")
+					/// Troutstation Edit End
 
 			if(start_immediately)
 				timeLeft = 0

--- a/code/modules/client/preferences/ready_job.dm
+++ b/code/modules/client/preferences/ready_job.dm
@@ -1,0 +1,5 @@
+/datum/preference/toggle/ready_job
+	savefile_key = "ready_job"
+	savefile_identifier = PREFERENCE_PLAYER
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	default_value = TRUE

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -384,4 +384,15 @@
 	if(CONFIG_GET(flag/auto_deadmin_on_ready_or_latejoin) || (client.prefs.read_preference(/datum/preference/toggle/auto_deadmin_on_ready_or_latejoin)) || (client.prefs?.toggles & DEADMIN_ALWAYS))
 		return client.holder.auto_deadmin()
 
+
+
+/// Troutstation Edit Start
+/mob/dead/new_player/get_status_tab_items()
+	. = ..()
+	if(SSticker.HasRoundStarted())
+		return
+
+	. += SSticker.player_ready_data
+/// Troutstation Edit End
+
 #undef RESET_HUD_INTERVAL

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -572,3 +572,7 @@ SPY_EASY_REWARD_TC_THRESHOLD 5
 ## Hard bounties grant uplink rewards that cost this much TC (or higher).
 ## Also functions as the upper end for medium bounties.
 SPY_HARD_REWARD_TC_THRESHOLD 15
+
+## TROUTSTATION EDIT
+## Enabling this shows all players the job estimates for the round during the lobby phase.
+SHOW_JOB_ESTIMATION

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4073,6 +4073,7 @@
 #include "code\modules\client\preferences\prosthetic_organ.dm"
 #include "code\modules\client\preferences\random.dm"
 #include "code\modules\client\preferences\rds_limit.dm"
+#include "code\modules\client\preferences\ready_job.dm"
 #include "code\modules\client\preferences\runechat.dm"
 #include "code\modules\client\preferences\scaling_method.dm"
 #include "code\modules\client\preferences\scarred_eye.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/show_ready.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/show_ready.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, type FeatureToggle } from '../base';
+
+export const ready_job: FeatureToggle = {
+  name: 'Show Ready Job In Lobby',
+  category: 'GAMEPLAY',
+  description: 'Show your Ckey and Job when you are readied up in the lobby.',
+  component: CheckboxInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/show_ready.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/show_ready.tsx
@@ -3,6 +3,7 @@ import { CheckboxInput, type FeatureToggle } from '../base';
 export const ready_job: FeatureToggle = {
   name: 'Show Ready Job In Lobby',
   category: 'GAMEPLAY',
-  description: 'Show your Ckey and Job when you are readied up in the lobby.',
+  description:
+    'Adds your highest preferred Job to a tally when you are readied up in the lobby.',
   component: CheckboxInput,
 };


### PR DESCRIPTION
## About The Pull Request

Job estimator, displays how many of each role are set as highest preference across readied up users.
Taken from [daedalusdock](https://github.com/DaedalusDock/daedalusdock) and edited to make it a bit more anonymous (formerly would tell you each individual readied up player's highest preferred role, now just gives a number for how many people picking that role).

I'm unable to test this locally with more than one player, so I'd recommend this for test merging first.

Please don't forget to edit the server config file!

## Why It's Good For The Game

We have issues with rounds having too much of one role, and then people adjusting to fill that gap the next round, leaving the initial role empty. 
Some players pick their role after the game starts to try balance this.
With this preview it should show where people are allocated and make the decision before the game starts.

## Changelog

:cl:
add: Added job estimator in the lobby
/:cl:
