### PR TITLE
Gay Skitterer Ghost Role Fix

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -41,6 +41,7 @@
 #define POLL_IGNORE_RECOVERED_CREW "recovered_crew"
 #define POLL_IGNORE_EXPERIMENTAL_CLONER "experimental_cloner"
 #define POLL_IGNORE_FREE_SPORE "free_spore"
+#define POLL_IGNORE_GAY_SKITTERER "gay_skitterer" // Troutstation Edit
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_ACADEMY_WIZARD = "Academy Wizard Defender",
@@ -82,6 +83,7 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_VENUSHUMANTRAP = "Venus Human Traps",
 	POLL_IGNORE_RECOVERED_CREW = "Recovered Crew",
 	POLL_IGNORE_FREE_SPORE = "Free spore",
+	POLL_IGNORE_GAY_SKITTERER = "Gay Skitterer", // Troutstation Edit
 ))
 GLOBAL_LIST_INIT(poll_ignore, init_poll_ignore())
 

--- a/troutstation/code/modules/mob/living/basic/space_fauna/skitterer.dm
+++ b/troutstation/code/modules/mob/living/basic/space_fauna/skitterer.dm
@@ -119,6 +119,24 @@
 	)
 	grant_actions_by_list(innate_actions)
 
+	AddComponent(\
+		/datum/component/ghost_direct_control,\
+		poll_candidates = TRUE,\
+		role_name = "Gay Skitterer",\
+		poll_ignore_key = POLL_IGNORE_GAY_SKITTERER,\
+		assumed_control_message = "You are a Gay Skitterer. You are a Skitterer but Gay. Go on, gayass. Be gay.",\
+		poll_length = 30 SECONDS,\
+		after_assumed_control = CALLBACK(src, PROC_REF(became_player_controlled)),\
+		poll_chat_border_icon = /mob/living/basic/skitterer,\
+	)
+
+/mob/living/basic/gay_skitterer/proc/became_player_controlled()
+	notify_ghosts(
+		"A Gay Skitterer has gained sentience in \the [get_area(src)].",
+		source = src,
+		header = "Gay Skitterer Sentience",
+		notify_flags = NOTIFY_CATEGORY_NOFLASH,
+	)
 
 /datum/ai_controller/basic_controller/skitterer
 	blackboard = list(


### PR DESCRIPTION

## About The Pull Request

When a gay skitterer spawns, a ghost may now play it. 

## Why It's Good For The Game

Before, a gay skitterer was only ghost controllable when it was converted to gay. Now the option is just There.

## Changelog

:cl:
add: Gay Skitterers are ghost controllable
/:cl:
