### PR TITLE
Tisserand fixes 3

### DIFF
--- a/_maps/map_files/TissStation/TissStation.dmm
+++ b/_maps/map_files/TissStation/TissStation.dmm
@@ -27063,6 +27063,10 @@
 	name = "Virology Break Room"
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/mapping_helpers/airlock_note_placer{
+	note_info = "ing in";
+	note_name = "note"
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/virology)
 "ikz" = (

--- a/_maps/map_files/TissStation/TissStation.dmm
+++ b/_maps/map_files/TissStation/TissStation.dmm
@@ -1741,7 +1741,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "aAv" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -5517,7 +5517,7 @@
 	name = "Lock Control"
 	},
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "bJm" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/janitor)
@@ -9536,7 +9536,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "cVm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/meter,
@@ -11504,7 +11504,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "dyT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -12648,7 +12648,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "dSi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -15191,6 +15191,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/sink/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "eGd" = (
@@ -19103,7 +19104,7 @@
 /obj/machinery/recharge_station,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "fNv" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 10
@@ -20482,7 +20483,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/unres/delayed,
 /turf/open/floor/plating,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "glB" = (
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -22704,7 +22705,7 @@
 	},
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "gVA" = (
 /obj/structure/railing{
 	dir = 8
@@ -28100,6 +28101,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/tram/sciai)
+"iyJ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/cargo/breakroom)
 "iyP" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
@@ -28577,7 +28585,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "iFo" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain)
@@ -30252,7 +30260,7 @@
 /area/station/science/explab)
 "jgE" = (
 /turf/closed/wall/r_wall,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "jgO" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/directional/west{
@@ -32997,8 +33005,8 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/sink/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "jUs" = (
@@ -38598,7 +38606,7 @@
 	name = "Lock Control"
 	},
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "lAu" = (
 /obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40597,7 +40605,7 @@
 	name = "Robot Toilet"
 	},
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "mes" = (
 /obj/structure/table/reinforced,
 /obj/structure/desk_bell{
@@ -41577,7 +41585,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/medical_doctor,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "mtG" = (
@@ -43865,7 +43873,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "nez" = (
 /obj/machinery/computer/mecha,
 /obj/machinery/computer/security/telescreen/rd/directional/west,
@@ -45720,6 +45728,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "nHp" = (
@@ -45742,7 +45751,7 @@
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "nHZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -48031,7 +48040,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "ouC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -48689,7 +48698,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "oHj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access"
@@ -55295,7 +55304,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "qGx" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -56679,7 +56688,7 @@
 	name = "Lock Control"
 	},
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "rbB" = (
 /obj/structure/table,
 /obj/machinery/fax{
@@ -56896,6 +56905,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"reI" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/station/medical/break_room)
 "reL" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/layer2{
 	dir = 8
@@ -62918,7 +62936,7 @@
 /obj/machinery/duct,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "taq" = (
 /obj/item/radio/intercom/directional/west{
 	freerange = 1;
@@ -64650,7 +64668,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "tEo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1;
@@ -64800,7 +64818,7 @@
 /obj/structure/sink/directional/north,
 /obj/structure/mirror/directional/south,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "tGk" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -73793,8 +73811,9 @@
 "wsQ" = (
 /obj/structure/sign/poster/official/cleanliness/directional/south,
 /obj/machinery/light/small/directional/south,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "wsR" = (
 /obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -75828,7 +75847,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "xbi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -76940,7 +76959,7 @@
 /obj/structure/curtain,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/area/station/commons/toilet/auxiliary)
 "xtO" = (
 /obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78345,6 +78364,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/newscaster/directional/south,
+/obj/structure/sink/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "xQB" = (
@@ -89447,7 +89467,7 @@ vIy
 vIy
 uYA
 jKQ
-amx
+reI
 myH
 chX
 tax
@@ -96033,7 +96053,7 @@ tdW
 yda
 xtD
 eYs
-oKs
+iyJ
 eoU
 jsE
 xTo

--- a/_maps/map_files/TissStation/TissStation.dmm
+++ b/_maps/map_files/TissStation/TissStation.dmm
@@ -337,7 +337,7 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/obj/item/stack/medical/gauze{
+/obj/item/stack/medical/wrap/gauze{
 	pixel_x = 8
 	},
 /obj/structure/railing/corner{
@@ -1726,6 +1726,13 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /obj/effect/turf_decal/tile/yellow/full,
 /obj/machinery/light/directional/south,
+/obj/item/electronics/apc{
+	pixel_x = -15
+	},
+/obj/item/electronics/apc{
+	pixel_x = 14;
+	pixel_y = 7
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
 "aAo" = (
@@ -8061,11 +8068,64 @@
 /area/station/security/prison)
 "cAP" = (
 /obj/structure/table,
-/obj/item/electronics/apc,
-/obj/item/electronics/airlock,
-/obj/item/plant_analyzer{
-	pixel_y = 4;
-	pixel_x = -18
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -15
+	},
+/obj/item/stock_parts/subspace/transmitter{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -15
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -15
+	},
+/obj/item/stock_parts/subspace/transmitter{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_y = 7;
+	pixel_x = 9
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_y = 7;
+	pixel_x = 9
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_y = 7;
+	pixel_x = 9
+	},
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_x = 8;
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
@@ -8697,6 +8757,14 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"cKh" = (
+/obj/machinery/camera/emp_proof{
+	dir = 8;
+	network = list("ss13","engine");
+	c_tag = "Engineering - Supermatter Engine"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "cKj" = (
 /obj/machinery/computer/quantum_console{
 	dir = 4
@@ -19941,6 +20009,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/end,
 /obj/structure/sign/warning/radiation/rad_area/directional/south,
+/obj/machinery/camera/emp_proof{
+	dir = 8;
+	network = list("ss13","engine");
+	c_tag = "Engineering - Supermatter Pre-Chamber"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "gcV" = (
@@ -24494,6 +24567,10 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/power_store/cell/high,
+/obj/item/plant_analyzer{
+	pixel_y = 8;
+	pixel_x = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
 "hyD" = (
@@ -38085,6 +38162,7 @@
 "ltj" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/light/no_nightlight/directional/south,
 /turf/open/floor/iron/terracotta,
 /area/station/service/hydroponics/garden)
 "ltl" = (
@@ -40268,20 +40346,6 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai/satellite/interior)
-"maD" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable/layer1,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored{
-	cable_layer = 1
-	},
-/obj/machinery/camera/emp_proof{
-	dir = 8;
-	network = list("ss13","engine");
-	c_tag = "Engineering - Supermatter Engine"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
 "maU" = (
 /obj/structure/railing{
 	dir = 4
@@ -42811,7 +42875,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "mPI" = (
 /obj/structure/table/glass,
-/obj/item/stack/sticky_tape/surgical,
+/obj/item/stack/medical/wrap/sticky_tape/surgical,
 /obj/item/stack/medical/bone_gel,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -45807,7 +45871,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
 	},
-/obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/terracotta,
 /area/station/service/hydroponics/garden)
@@ -67218,6 +67281,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
+"uvd" = (
+/obj/machinery/light/directional/south,
+/turf/open/water/no_planet_atmos/deep,
+/area/station/service/hydroponics/garden)
 "uvg" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
@@ -67934,7 +68001,7 @@
 	id_tag = "stasis2"
 	},
 /obj/item/stack/medical/mesh,
-/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/wrap/gauze,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "uFB" = (
@@ -68943,7 +69010,7 @@
 /area/station/engineering/atmos)
 "uTQ" = (
 /obj/structure/table/glass,
-/obj/item/stack/sticky_tape/surgical,
+/obj/item/stack/medical/wrap/sticky_tape/surgical,
 /obj/item/stack/medical/bone_gel,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -76906,7 +76973,7 @@
 /obj/machinery/vitals_reader/directional/east{
 	id_tag = "stasis1"
 	},
-/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/wrap/gauze,
 /obj/item/stack/medical/suture,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
@@ -100949,8 +101016,8 @@ fOx
 rMb
 ePt
 fbB
-hGz
-maD
+cKh
+iDq
 uvP
 jaP
 cmm
@@ -117575,7 +117642,7 @@ roe
 dIy
 fnI
 rYs
-sXK
+uvd
 roe
 jEl
 jEl

--- a/_maps/map_files/TissStation/TissStation.dmm
+++ b/_maps/map_files/TissStation/TissStation.dmm
@@ -5931,7 +5931,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/walkway)
 "bSb" = (
-/obj/effect/mob_spawn/corpse/human/cmo,
+/obj/effect/mob_spawn/corpse/human/doctor,
 /obj/effect/spawner/random/entertainment/plushie_delux,
 /obj/effect/spawner/random/exotic/tool{
 	pixel_x = -5;
@@ -9622,6 +9622,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"cYg" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/security/walkway)
 "cYt" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -10163,6 +10171,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"dgw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/mob_spawn/corpse/human/nanotrasensoldier,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dgA" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -12606,6 +12620,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -21261,6 +21276,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/walkway)
+"gyh" = (
+/obj/structure/fake_stairs/directional/west,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/medical/walkway)
 "gyk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -25972,6 +25992,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/walkway)
+"hTZ" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/turf/open/floor/plating,
+/area/station/medical/walkway)
 "hUf" = (
 /obj/structure/table/glass,
 /obj/item/clothing/accessory/armband/hydro,
@@ -30436,6 +30464,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
+"jjY" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/walkway)
 "jka" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -31449,6 +31485,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/science/robotics/augments)
 "jwy" = (
@@ -31459,6 +31496,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"jwA" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/station/medical/walkway)
 "jwH" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Civilian - Dormitories #2";
@@ -31852,7 +31895,7 @@
 /area/station/command/heads_quarters/hos)
 "jDZ" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33116,7 +33159,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/walkway)
 "jWu" = (
@@ -36448,12 +36490,6 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/virology)
-"kSY" = (
-/obj/structure/fake_stairs/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/medical/walkway)
 "kTo" = (
 /obj/structure/fake_stairs/directional/east,
 /obj/structure/sign/departments/cargo/directional/south,
@@ -44357,6 +44393,14 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/pumproom)
+"nmP" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/cargo/walkway)
 "nmR" = (
 /obj/structure/chair/pew/left{
 	dir = 4;
@@ -46019,7 +46063,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/security/execution/transfer)
 "nMW" = (
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/station/science/research)
@@ -47596,7 +47640,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49163,6 +49207,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"oOP" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/cargo/walkway)
 "oOW" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -55748,13 +55800,6 @@
 	dir = 4
 	},
 /area/station/security/execution/transfer)
-"qPP" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/medical/walkway)
 "qPQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60898,6 +60943,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"svU" = (
+/turf/open/floor/plating,
+/area/station/medical/walkway)
 "svW" = (
 /obj/effect/turf_decal/stripes/white/end{
 	color = "#0066FF"
@@ -62199,6 +62247,9 @@
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/misc/grass/jungle/station,
 /area/station/security/prison)
+"sQn" = (
+/turf/open/floor/plating,
+/area/station/cargo/walkway)
 "sQp" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
@@ -64673,7 +64724,7 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "tFi" = (
@@ -64763,6 +64814,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"tGB" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/turf/open/floor/plating,
+/area/station/medical/walkway)
 "tGK" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/transit_tube/diagonal,
@@ -74876,6 +74933,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/tram/sciai)
+"wMb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/bronze,
+/obj/effect/mob_spawn/corpse/human/pirate/ranged/space,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wMd" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
@@ -79323,6 +79386,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"yfo" = (
+/turf/open/floor/plating,
+/area/station/security/walkway)
 "yfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -97354,14 +97420,14 @@ elN
 kqo
 elN
 elN
-elN
-elN
+rsl
+rsl
 rsl
 rsl
 fAa
 irz
 tOZ
-kSY
+tOZ
 uYA
 vIy
 jHq
@@ -97611,14 +97677,14 @@ elN
 kqo
 elN
 elN
-elN
-elN
-tIG
+tGB
+svU
+hTZ
 vaw
 tEW
 eBY
 okt
-qPP
+svi
 uYA
 vIy
 jHq
@@ -97868,10 +97934,10 @@ elN
 kqo
 elN
 elN
-elN
-tIG
-tIG
-sZP
+rsl
+rsl
+rsl
+jwA
 nlI
 okt
 sZP
@@ -101203,7 +101269,7 @@ wLM
 ohK
 ohK
 rsl
-ppi
+gyh
 loC
 eLa
 ppi
@@ -105769,9 +105835,9 @@ elN
 elN
 elN
 elN
-ggm
-ggm
-ggm
+hQX
+nmP
+hQX
 hQX
 hQX
 hQX
@@ -106026,9 +106092,9 @@ elN
 elN
 elN
 elN
-elN
-elN
-elN
+hQX
+sQn
+hQX
 xeM
 ohK
 ohK
@@ -106283,9 +106349,9 @@ elN
 elN
 elN
 elN
-elN
-elN
-elN
+hQX
+oOP
+hQX
 elN
 xeM
 ohK
@@ -106518,7 +106584,7 @@ elN
 elN
 elN
 aNm
-eYb
+wMb
 eYb
 eYb
 jPx
@@ -117856,8 +117922,8 @@ elN
 elN
 elN
 elN
-elN
-elN
+mLR
+jjY
 mLR
 vXU
 oCf
@@ -118113,8 +118179,8 @@ elN
 elN
 elN
 elN
-elN
-elN
+mLR
+yfo
 mLR
 ubC
 ubC
@@ -118338,7 +118404,7 @@ elN
 elN
 elN
 dgI
-gQL
+dgw
 gQL
 mLB
 dXF
@@ -118370,8 +118436,8 @@ elN
 elN
 elN
 pmJ
-pmJ
-pmJ
+mLR
+cYg
 mLR
 ubC
 ubC

--- a/_maps/map_files/TissStation/TissStation.dmm
+++ b/_maps/map_files/TissStation/TissStation.dmm
@@ -4277,6 +4277,7 @@
 /area/station/command/heads_quarters/ce)
 "boQ" = (
 /obj/structure/cable,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "bpp" = (
@@ -8214,6 +8215,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/rec)
+"cBM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	name = "Coroner's Office";
+	req_access = list("morgue_secure")
+	},
+/turf/open/floor/plating,
+/area/station/medical/chemistry/walkway)
 "cCh" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -27348,6 +27362,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"inP" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/station/cargo/walkway)
 "inU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -60019,7 +60037,6 @@
 /area/station/ai/satellite/foyer)
 "shP" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
 "shV" = (
@@ -60947,6 +60964,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "svU" = (
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/medical/walkway)
 "svW" = (
@@ -62251,6 +62269,7 @@
 /turf/open/misc/grass/jungle/station,
 /area/station/security/prison)
 "sQn" = (
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/cargo/walkway)
 "sQp" = (
@@ -63542,7 +63561,9 @@
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/dead_body_placer,
+/obj/effect/mapping_helpers/dead_body_placer{
+	bodycount = 6
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
@@ -64259,6 +64280,10 @@
 "txw" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/rec)
+"txE" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/station/security/walkway)
 "txU" = (
 /obj/structure/bed{
 	dir = 1
@@ -74286,6 +74311,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"wAB" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/station/medical/walkway)
 "wAF" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
@@ -79392,6 +79421,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "yfo" = (
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/security/walkway)
 "yfz" = (
@@ -94112,7 +94142,7 @@ dex
 wMj
 gBu
 bwe
-bwe
+cBM
 bwe
 bwe
 bwe
@@ -97168,9 +97198,9 @@ elN
 kqo
 elN
 elN
-elN
-elN
-elN
+rsl
+rsl
+rsl
 rsl
 fAh
 irz
@@ -97426,7 +97456,7 @@ kqo
 elN
 elN
 rsl
-rsl
+wAB
 rsl
 rsl
 fAa
@@ -105583,7 +105613,7 @@ elN
 elN
 elN
 ggm
-ggm
+jVs
 iXk
 pen
 gaC
@@ -105839,7 +105869,7 @@ elN
 elN
 elN
 elN
-elN
+hQX
 hQX
 nmP
 hQX
@@ -106096,8 +106126,8 @@ elN
 elN
 elN
 elN
-elN
 hQX
+inP
 sQn
 hQX
 xeM
@@ -106353,7 +106383,7 @@ elN
 elN
 elN
 elN
-elN
+hQX
 hQX
 oOP
 hQX
@@ -117926,7 +117956,7 @@ elN
 elN
 elN
 elN
-elN
+mLR
 mLR
 jjY
 mLR
@@ -118183,8 +118213,8 @@ elN
 elN
 elN
 elN
-elN
 mLR
+txE
 yfo
 mLR
 ubC
@@ -118440,7 +118470,7 @@ elN
 elN
 elN
 elN
-pmJ
+mLR
 mLR
 cYg
 mLR
@@ -118697,7 +118727,7 @@ elN
 elN
 elN
 pmJ
-pmJ
+mLR
 mKm
 sgo
 sgo

--- a/_maps/map_files/TissStation/TissStation.dmm
+++ b/_maps/map_files/TissStation/TissStation.dmm
@@ -1196,14 +1196,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/fore/port)
 "arB" = (
-/obj/machinery/holopad,
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/camera/directional/north{
 	network = list("ss13","medbay");
 	c_tag = "Medical - Morgue Interior";
 	dir = 4
 	},
-/turf/open/floor/iron/dark/herringbone,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/obj/structure/bodycontainer/morgue/beeper_off{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "arN" = (
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
@@ -20439,16 +20444,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/work)
 "gkP" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "gkS" = (
@@ -25116,27 +25112,22 @@
 /turf/open/misc/grass/jungle/station,
 /area/station/security/prison)
 "hHc" = (
-/obj/effect/turf_decal/trimline/neutral/end{
-	dir = 4
+/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/mid_joiner,
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
 	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
-	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
@@ -26460,12 +26451,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/detectives_office)
 "iaI" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 8
 	},

--- a/_maps/map_files/TissStation/maintenance_modules/disposals_2.dmm
+++ b/_maps/map_files/TissStation/maintenance_modules/disposals_2.dmm
@@ -123,7 +123,7 @@
 	dir = 8
 	},
 /obj/machinery/recycler{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/spawner/directional/north{
 	pixel_y = 4

--- a/_maps/map_files/TissStation/maintenance_modules/mainOuterEast_1.dmm
+++ b/_maps/map_files/TissStation/maintenance_modules/mainOuterEast_1.dmm
@@ -458,9 +458,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "si" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -850,6 +848,7 @@
 /area/station/commons/fitness/recreation/bowling)
 "Me" = (
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/eighties,
 /area/station/commons/fitness/recreation/bowling)
 "Mr" = (

--- a/_maps/map_files/TissStation/maintenance_modules/mainOuterEast_2.dmm
+++ b/_maps/map_files/TissStation/maintenance_modules/mainOuterEast_2.dmm
@@ -954,7 +954,7 @@
 "NN" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Of" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/shuttles/emergency_tiss.dmm
+++ b/_maps/shuttles/emergency_tiss.dmm
@@ -68,6 +68,9 @@
 /area/shuttle/escape)
 "fX" = (
 /obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "gv" = (
@@ -804,6 +807,9 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/dim/directional/east,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "VU" = (

--- a/_maps/tissstation.json
+++ b/_maps/tissstation.json
@@ -9,11 +9,6 @@
 		"cargo": "cargo_tiss",
 		"whiteship": "whiteship_tiss"
 	},
-	"traits": [
-		{
-			"Linkage": "Grid"
-		}
-	],
 	"job_changes": {
 		"Cook": {
 			"additional_cqc_areas": ["/area/station/commons/park"]

--- a/_maps/tissstation.json
+++ b/_maps/tissstation.json
@@ -9,6 +9,11 @@
 		"cargo": "cargo_tiss",
 		"whiteship": "whiteship_tiss"
 	},
+	"traits": [
+		{
+			"Linkage": "Grid"
+		}
+	],
 	"job_changes": {
 		"Cook": {
 			"additional_cqc_areas": ["/area/station/commons/park"]


### PR DESCRIPTION

## About The Pull Request

Weekly fixes/changes for Tisserand

## Changelog


:cl:
map: Tisserand: fixed camera in engine pre-chamber
map: Tisserand: fixed recycler direction
map: Tisserand: added fancy tech items in storage
map: Tisserand: fixed maint to department accesses
map: Tisserand: fixed bowling alley power and pipes
map: Tisserand: medical walkway alarms now accessible
map: Tisserand: added exits to space to departmental walkways
map: Tisserand: added sinks to break rooms
map: Tisserand: added navigation verbs to bathrooms
map: Tisserand: added rechargers to escape shuttle cockpit
map: Tisserand: added additional secure morgue in coroner's office
/:cl:
