### PR TITLE
Lets moths color themselves

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -10,6 +10,9 @@
 		/obj/item/organ/wings/moth = "Plain",
 		/obj/item/organ/antennae = "Plain",
 	)
+	inherent_traits = list(
+		TRAIT_MUTANT_COLORS,
+	)
 	meat = /obj/item/food/meat/slab/human/mutant/moth
 	mutanttongue = /obj/item/organ/tongue/moth
 	mutanteyes = /obj/item/organ/eyes/moth


### PR DESCRIPTION

## About The Pull Request
Lets moths recolor their skin
## Why It's Good For The Game
Oversight , a lot of the moth styles rely on recoloring to be proper
## Changelog
:cl: SPCR
fix: Fixed moths being unable to recolor 
/:cl:
